### PR TITLE
feat: enable script for production builds

### DIFF
--- a/scripts/android-clean-vm.sh
+++ b/scripts/android-clean-vm.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
 
 # Deletes all data created by previous VMs
-# Requires debuggable build
 
-adb root
-adb shell rm -rfv /data/data/com.android.virtualization.terminal/{files/nixos.log,files/debian.log,files/linux,vm/nixos,vm/debian}
-
+adb shell "su -c 'rm -rfv /data/data/com.android.virtualization.terminal/{files/nixos.log,files/debian.log,files/linux,vm/nixos,vm/debian}'"


### PR DESCRIPTION
I'm unsure if this is desired, but I thought it might be worth pointing out that you can run `android-clean-vm.sh` for production builds when you have root.

I also just noticed that this commit `chmod +x`'s the script - unsure if that's desired either.