### PR TITLE
docs: add commands for pulling protected logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,15 @@ Try restarting the app. Try re-installing the image if that doesn't help.
 
 ### With root
 
-Check /data/data/com.android.virtualization.terminal/files/nixos.log
+Check /data/data/com.android.virtualization.terminal/files/nixos.log. You can pull it with:
+
+```sh
+adb shell "su -c '
+  cp /data/data/com.android.virtualization.terminal/files/nixos.log /data/local/tmp/nixos.log
+  chown shell.shell /data/local/tmp/nixos.log
+'"
+adb pull /data/local/tmp/nixos.log
+```
 
 If the log contains `EFI boot manager: Cannot load any image` or is missing any systemd messages like "Started xyz.service..." then the image might be corrupted
 


### PR DESCRIPTION
The `/data/data/com.android.virtualization.terminal/files/nixos.log` file is in a protected location, so you have to move them to a temporary location and take ownership of them before you can pull them with adb.