### PR TITLE
fix: disable obsolete patch for libwebsockets >= v4.3.6

### DIFF
--- a/avf/pkgs.nix
+++ b/avf/pkgs.nix
@@ -47,11 +47,14 @@ in
 {
   ttyd =
     (ttyd.override {
-      libwebsockets = libwebsockets.overrideAttrs (_: {
-        patches = [
-          "${base}/build/debian/ttyd/client_cert.patch"
-        ];
-      });
+      libwebsockets = libwebsockets.overrideAttrs (
+        a:
+        lib.optionalAttrs (lib.strings.versionOlder a.version "4.3.6") {
+          patches = [
+            "${base}/build/debian/ttyd/client_cert.patch"
+          ];
+        }
+      );
     }).overrideAttrs
       (a: {
         patches = [


### PR DESCRIPTION
Fixes https://github.com/nix-community/nixos-avf/issues/20.

~~Note: libwebsockets is currently at v4.3.5 in NixOS 25.11, and it may be still updated to v4.3.7. I didn't test whether the patch applies for that version.~~
**EDIT**: patch is now only applied to versions older than v4.3.5.