### PR TITLE
fix: vm name must be "debian" for display output to work

### DIFF
--- a/avf/default.nix
+++ b/avf/default.nix
@@ -81,7 +81,8 @@ with lib;
 
   config = {
     avf.vmConfig = {
-      name = "nixos";
+      # VM name must be "debian" for display output to work
+      name = "debian";
       disks = [
         {
           partitions = [


### PR DESCRIPTION
The Linux Terminal app looks up its VM by this hardcoded name, see: https://android.googlesource.com/platform/packages/modules/Virtualization/+/refs/tags/android-16.0.0_r2/android/TerminalApp/java/com/android/virtualization/terminal/DisplayActivity.kt#39

Otherwise, if there's no VM by that name, the app will crash with a NullPointerException upon launching the display activity.