### PR TITLE
fix: update vm_config.json instead of recreating file

### DIFF
--- a/avf/default.nix
+++ b/avf/default.nix
@@ -228,7 +228,9 @@ with lib;
         ${pkgs.coreutils}/bin/cp -v ${config.system.build.vmConfig} /tmp/vm_config.json.new
         ${pkgs.gnused}/bin/sed -i "s/{efi_part_guid}/$(${pkgs.util-linux}/bin/sfdisk --part-uuid /dev/vda 1)/g" /tmp/vm_config.json.new
         ${pkgs.gnused}/bin/sed -i "s/{root_part_guid}/$(${pkgs.util-linux}/bin/sfdisk --part-uuid /dev/vda 2)/g" /tmp/vm_config.json.new
-        ${pkgs.coreutils}/bin/mv -v /tmp/vm_config.json.new /mnt/internal/linux/vm_config.json
+        # NOTE: do not remove and recreate file (AVF doesn't allow the latter),
+        # but truncate the existing one and update it with the new contents.
+        ${pkgs.coreutils}/bin/cat /tmp/vm_config.json.new > /mnt/internal/linux/vm_config.json
       fi
     '';
 


### PR DESCRIPTION
## Note

I noticed this issue a while ago, but I have neither tried to reproduce it since nor have I actually tested my fix yet (both would require re-installing the VM, which takes a lot of time with my NixOS configuration).
I thought I'd leave it here in case anybody else is encountering the same issue. Also I will forget about it again otherwise :see_no_evil:

## Commit message

When mv overwrites a file, it will remove the destination file and replace it with the source file (in case it is on the same filesystem, in which it will use the source file's inode) or with a new file that has the content of the source file (if the source file is on another filesystem, in which case it will remove the source after copying it).

For some reason, the mounted filesystem (VirtioFS IIRC) that contains the vm_config.json does not like it being replaced, and it is impossible to write the new file after the old one has been deleted. (n=1, this has been my experience but I don't have a source link and haven't tried to reproduce it).

What works, however, is updating the contents of vm_config.json by opening the existing file, truncating it, and writing the content of our source file to it.

Note: while cp (at least the one from coreutils) exhibits the same behavior by default (but can recreate files when using -f/--force), using the shell redirection here makes clear what is going on.

Note 2: Yes, it's possible to do this entirely with shell redirects in the form of `>dst <src` (or the other way around), but `cat` is what everybody knows and loves.