### PR TITLE
Get rid of deprecation warnings on nixos-unstable

### DIFF
--- a/avf/default.nix
+++ b/avf/default.nix
@@ -414,7 +414,11 @@ with lib;
     systemd.network.enable = true;
     networking.useNetworkd = true;
     networking.dhcpcd.enable = false;
-    services.resolved.dnssec = "false";
+    services.resolved =
+      if builtins.hasAttr "settings" config.services.resolved then
+        { settings.Resolve.DNSSEC = false; }
+      else
+        { dnssec = "false"; };
     networking.useDHCP = true;
     networking.firewall.enable = true; # default
     networking.nftables.enable = true;

--- a/avf/default.nix
+++ b/avf/default.nix
@@ -14,6 +14,8 @@ let
   };
   extraPkgs = pkgs.callPackage ./pkgs.nix { inherit base; };
 
+  mesaDrivers = if builtins.elem "drivers" pkgs.mesa.outputs then pkgs.mesa.drivers else pkgs.mesa;
+
   serialDevice = "ttyS0";
 
   mkService = name: {
@@ -396,7 +398,7 @@ with lib;
       };
 
       environment = {
-        LIBGL_DRIVERS_PATH = "${pkgs.mesa.drivers}/lib/dri";
+        LIBGL_DRIVERS_PATH = "${mesaDrivers}/lib/dri";
         LD_LIBRARY_PATH = "/run/opengl-driver/lib";
       };
     };


### PR DESCRIPTION
I've fixed the module to not produce deprecation warnings on nixos-unstable while still keeping backwards compatibility for the supported channels.